### PR TITLE
Update READme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Have a look at the [CONTRIBUTING](/CONTRIBUTING.md) and [CODE_OF_CONDUCT](/CODE_
 ## Getting started developing
 
 ```bash
-# set up husky
-$ yarn prepare
-
 # install dependencies
 $ yarn install
+
+# set up husky
+$ yarn prepare
 
 # For Development, start a dev server with hot reloading at localhost:3000
 $ yarn dev


### PR DESCRIPTION
Resolves: small issue in READme
If '$ yarn prepare' is run first, it returns an error of "Couldn't find the node_modules state file - running an install might help (findPackageLocation)".

# What changed
Under "Getting started developing", switched the places of '$ yarn install' and '$ yarn prepare' so the latter is now second. 
